### PR TITLE
Retrieve component when already exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v1
 
+## v1.2.0
+
+- Return components already created instead of failing
+
 ## v1.1.0
 
 - Use the package for the DCI client

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 GitHub Action to create a [DCI](https://docs.distributed-ci.io/) [component](https://docs.distributed-ci.io/#component) in multiple [topics](https://docs.distributed-ci.io/#topic).
 
+When a component already exists, the component will be retrieved, it will not update it.
+
 ## Usage
 
 ### Pre-requisites
@@ -18,7 +20,7 @@ To use this Action, a [RemoteCI](https://docs.distributed-ci.io/#remote-ci) is r
   - Set a name
   - Select team owner
 - Search your newly created RemoteCI
-  - Click on the Authenticate "blue incognito button"
+  - Under the Authentication column click on credentials.yaml
   - Copy on the button "Copy to clipboard"
 - Save the content in a file
 

--- a/add-component
+++ b/add-component
@@ -74,7 +74,36 @@ for topic in ${TOPICS[@]}; do
         ${COMPONENT_RELEASE} \
         ${tags} ${url} ${data}
     )
-    if [[ $(jq .status_code <<< "$output") -ne "null" ]]; then
+    status_code=$(jq -r .status_code <<< "${output}")
+    # Component already exists, retrieve it
+    if [[ "${status_code}" -eq "409" ]]; then
+        topic_id=$(jq -r .message <<< "${output}" |
+            grep -oP "'topic_id': '[^,]+" |
+            cut -d "'" -f4
+        )
+        type=$(jq -r .message <<< "${output}" |
+            grep -oP "'type': '[^,]+" |
+            cut -d "'" -f4
+        )
+        name=$(jq -r .message <<< "${output}" |
+            grep -oP "'name': '[^,]+" |
+            cut -d "'" -f4
+        )
+        query="type:${type},version:${COMPONENT_VERSION},name:${name}"
+        component=$(\
+            dcictl \
+            --format json \
+            component-list \
+            --topic-id ${topic_id} \
+            --where "${query}" |
+            jq -r '.components[0]'
+        )
+        if [[ "${component}" == "null" ]]; then
+            echo "Failed to find component ${name}"
+            exit 1
+        fi
+        output='{"component": '${component}'}'
+    elif [[ "${status_code}" -ne "null" ]]; then
         echo "Failed to create component for ${COMPONENT_NAME}-${COMPONENT_VERSION}"
         exit 1
     fi


### PR DESCRIPTION
Currently the GHA will fail if a a component to create already exists in DCI. Instead of failing the GHA will retrieve the component.