### PR TITLE
Add wildcard for the latest versions of a topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v1
 
+## v1.3.0
+
+- Add wildcard "all-*" for topics
+
 ## v1.2.0
 
 - Return components already created instead of failing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## v1.3.0
 
-- Add wildcard "all-*" for topics
+- Add wildcard "all-<TOPIC_TYPE>" for topics
 
 ## v1.2.0
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Some Inputs are required, while others are optional.
 
 - `dciClientId`: Remote CI client ID, this is passed as a secret.
 - `dciApiSecret`: Remote CI API secret, this is passed as a secret.
-- `dciTopics`: A comma-separated list of DCI topics example, or a wildcard for a particular topic, that uses all the latest versions of that topic.
+- `dciTopics`: A comma-separated list of DCI topics, or a special term `all-<TOPIC_TYPE>`for the latest (last 6) topics. Where `TOPIC_TYPE`is one of: `OCP`, `OSP` or `RHEL`.
 
     ```yaml
     # Single topic

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Some Inputs are required, while others are optional.
 
 - `dciClientId`: Remote CI client ID, this is passed as a secret.
 - `dciApiSecret`: Remote CI API secret, this is passed as a secret.
-- `dciTopics`: A comma-separated list of DCI topics example:
+- `dciTopics`: A comma-separated list of DCI topics example, or a wildcard for a particular topic, that uses all the latest versions of that topic.
 
     ```yaml
     # Single topic
@@ -57,6 +57,12 @@ Some Inputs are required, while others are optional.
 
     # Other topics
     dciTopics: RHEL-9.2
+
+    # All the latest versions of the OSP topic
+    dciTopics: all-osp
+
+    # All the latest versions of the OCP topic
+    dciTopics: all-OCP
     ```
 
 - `componentName`: DCI component name, e.g. `My Awesome Component` or `FredCo awesome operator` or `acme-component`, etc.
@@ -92,8 +98,7 @@ Creating component `My container application` with version `v1.2.3-alpha`, and `
         with:
           dciClientId: ${{ secrets.DCI_CLIENT_ID }}
           dciApiSecret: ${{ secrets.DCI_API_SECRET }}
-          dciTopics:
-            - "OCP-4.12"
+          dciTopics: "OCP-4.12"
           componentName: "My container application"
           componentVersion: v1.2.3
           componentRelease: "dev"
@@ -131,8 +136,7 @@ The output of the component created is stored in `components` and can be re-used
         with:
           dciClientId: ${{ secrets.DCI_CLIENT_ID }}
           dciApiSecret: ${{ secrets.DCI_API_SECRET }}
-          dciTopics:
-            - "OCP-4.12"
+          dciTopics: "OCP-4.12"
           componentName: "My container application"
           componentVersion: v1.2.3
           componentRelease: "dev"

--- a/add-component
+++ b/add-component
@@ -110,7 +110,7 @@ if [[ -z "${TOPICS[*]}" ]]; then
     exit 1
 fi
 
-# Detect wildcard topic "all-*"
+# Detect topic wildcard "all-<TOPIC_TYPE>"
 if [[ ${#TOPICS[@]} -eq 1 ]] && grep -q all- <<< "${TOPICS[0]}"; then
     old_topic=${TOPICS[0]}
     TOPICS=( $(get_topic_versions "${TOPICS[0]#all-*}") )

--- a/add-component
+++ b/add-component
@@ -8,10 +8,50 @@ function clean_up() {
 
 trap clean_up EXIT
 
+# Get the latest (last 6) versios of a topic
+function get_topic_versions(){
+    local topic_type=${1^^}
+    declare -A products
+    products=( [OCP]=OpenShift [OSP]=OpenStack [RHEL]=RHEL )
+
+    # get product from topic
+    product=${products[${topic_type}]}
+
+    if [[ -z ${product} ]]; then
+        echo "Invalid Topic Type: ${topic_type}"
+        echo "Valid Topic Types: ${VALID_DCI_TOPIC_TYPES[*]}"
+        exit 1
+    fi
+
+    # Get Product ID
+    product_id=$( dcictl \
+                  --format json \
+                  product-list \
+                  --where "name:${product}" |
+              jq -r '.products[].id'
+    )
+
+    all_versions=( $( dcictl \
+                      --format json \
+                      topic-list \
+                      --where "status:active" \
+                      --where "product_id:${product_id}" \
+                      --where "name:${topic_type}*" |
+                  jq -r '.topics[0:6][] | .name')
+    )
+    echo ${all_versions[@]}
+}
+
 VALID_DCI_RELEASE_TAGS=(
     dev
     candidate
     ga
+)
+
+VALID_DCI_TOPIC_TYPES=(
+    OCP
+    OSP
+    RHEL
 )
 
 # API Secrets
@@ -64,6 +104,22 @@ if [[ -n ${COMPONENT_DATA} ]]; then
     data="--data $(jq -c . <<<${COMPONENT_DATA})"
 fi
 
+# dciTopicVersion
+if [[ -z "${TOPICS[*]}" ]]; then
+    echo "No topics provided"
+    exit 1
+fi
+
+# Detect wildcard topic "all-*"
+if [[ ${#TOPICS[@]} -eq 1 ]] && grep -q all- <<< "${TOPICS[0]}"; then
+    old_topic=${TOPICS[0]}
+    TOPICS=( $(get_topic_versions "${TOPICS[0]#all-*}") )
+    if [[ $? -ne 0 ]]; then
+        echo "Failed to get versions for ${old_topic}"
+        exit 1
+    fi
+fi
+
 for topic in ${TOPICS[@]}; do
     output=$( \
         dci-create-component \
@@ -110,4 +166,4 @@ for topic in ${TOPICS[@]}; do
     jq . <<< "$output" >> ${components_file}
 done
 
-echo "components=$(jq -s -c '.' ${components_file})" >> ${GITHUB_OUTPUT}
+echo "components=$(jq -s -c '.' ${components_file})" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
This functionality was available on previous versions but was removed to allow multiple topics. Now allows to use all-* (OCP, OSP or RHEL) to get the latest (last 6 versions) of that topic.

Fix: #6 