### PR TITLE
Get 7 latest versions of topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1
 
-## v1.3.1
+## v1.4.0
 
 - Get last 7 versions of a topic if using "all-<TOPIC_TYPE>"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v1
 
+## v1.3.1
+
+- Get last 7 versions of a topic if using "all-<TOPIC_TYPE>"
+
 ## v1.3.0
 
 - Add wildcard "all-<TOPIC_TYPE>" for topics

--- a/add-component
+++ b/add-component
@@ -8,7 +8,7 @@ function clean_up() {
 
 trap clean_up EXIT
 
-# Get the latest (last 6) versios of a topic
+# Get the latest (last 7) versions of a topic
 function get_topic_versions(){
     local topic_type=${1^^}
     declare -A products
@@ -37,7 +37,7 @@ function get_topic_versions(){
                       --where "status:active" \
                       --where "product_id:${product_id}" \
                       --where "name:${topic_type}*" |
-                  jq -r '.topics[0:6][] | .name')
+                  jq -r '.topics[0:7][] | .name')
     )
     echo ${all_versions[@]}
 }


### PR DESCRIPTION
Currently, "all-<TOPIC_TYPE>" retrieves the last 6 versions of the topic. If using OCP, this implies that it will try to obtain from OCP 4.18 to OCP 4.13, so that it excludes OCP 4.12 that is still used.
Increasing the limit to 7 versions, so that OCP 4.12 can be used.