### PR TITLE
New Release 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v1
 
+## v1.5.0
+
+- Set a limit of topics to use with the wildcard "all-<TOPIC_TYPE>" based on the product.
+
 ## v1.4.0
 
 - Get last 7 versions of a topic if using "all-<TOPIC_TYPE>"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Some Inputs are required, while others are optional.
 
 - `dciClientId`: Remote CI client ID, this is passed as a secret.
 - `dciApiSecret`: Remote CI API secret, this is passed as a secret.
-- `dciTopics`: A comma-separated list of DCI topics, or a special term `all-<TOPIC_TYPE>`for the latest (last 6) topics. Where `TOPIC_TYPE`is one of: `OCP`, `OSP` or `RHEL`.
+- `dciTopics`: A comma-separated list of DCI topics, or a special term `all-<TOPIC_TYPE>` for the [latest topics](./dci-component/blob/main/add-component#L17). Where `TOPIC_TYPE`is one of: `OCP`, `OSP` or `RHEL`.
 
     ```yaml
     # Single topic

--- a/add-component
+++ b/add-component
@@ -8,14 +8,17 @@ function clean_up() {
 
 trap clean_up EXIT
 
-# Get the latest (last 7) versions of a topic
+# Get the latest versions of a topic per product
 function get_topic_versions(){
     local topic_type=${1^^}
+    declare -A limits
     declare -A products
+    limits=( [OCP]=8 [OSP]=2 [RHEL]=10 )
     products=( [OCP]=OpenShift [OSP]=OpenStack [RHEL]=RHEL )
 
-    # get product from topic
+    # get product and limit from topic
     product=${products[${topic_type}]}
+    limit=${limits[${topic_type}]}
 
     if [[ -z ${product} ]]; then
         echo "Invalid Topic Type: ${topic_type}"
@@ -37,7 +40,7 @@ function get_topic_versions(){
                       --where "status:active" \
                       --where "product_id:${product_id}" \
                       --where "name:${topic_type}*" |
-                  jq -r '.topics[0:7][] | .name')
+                  jq -r '.topics[0:'${limit}'][] | .name')
     )
     echo ${all_versions[@]}
 }


### PR DESCRIPTION
Add limits per topic

For the 'all-*' topic type, use a predefine number of topics, depending on the product, this is to attempt to align to supported versions of the topic to use to create a component.