### PR TITLE
Update limit for OCP component creation

### DIFF
--- a/add-component
+++ b/add-component
@@ -13,7 +13,7 @@ function get_topic_versions(){
     local topic_type=${1^^}
     declare -A limits
     declare -A products
-    limits=( [OCP]=8 [OSP]=2 [RHEL]=10 )
+    limits=( [OCP]=9 [OSP]=2 [RHEL]=10 )
     products=( [OCP]=OpenShift [OSP]=OpenStack [RHEL]=RHEL )
 
     # get product and limit from topic


### PR DESCRIPTION
With OCP 4.20, and since 4.12 is still under maintenance, we need to update the limit for OCP component creation so that OCP 4.12 is not discarded.