### PR TITLE
Update base image and add new buildtype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## v1
 
+## v1.6.0
+
+- Use ubi9-minimal image
+- Increase the limit for OCP topics when using all-OCP.
+- Add buildtype: nightly
+
 ## v1.5.0
 
 - Set a limit of topics to use with the wildcard "all-<TOPIC_TYPE>" based on the product.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 ARG VERSION=latest
-FROM registry.access.redhat.com/ubi8/ubi:${VERSION}
+FROM registry.access.redhat.com/ubi9/ubi-minimal:${VERSION}
 
-RUN dnf -y install https://packages.distributed-ci.io/dci-release.el8.noarch.rpm && \
-  dnf install -y \
+RUN rpm -iv https://packages.distributed-ci.io/dci-release.el9.noarch.rpm
+RUN microdnf install -y \
   python3 \
   jq \
   python3-dciclient && \

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Some Inputs are required, while others are optional.
 
 - `componentName`: DCI component name, e.g. `My Awesome Component` or `FredCo awesome operator` or `acme-component`, etc.
 - `componentVersion`: DCI component version, the version of the component to create, e.g. `v1.2.3`, `22.10`, `9.2-rc1`, `v12.28.12-alpha`, etc.
-- `componentRelease`: DCI component release tag must be one of the following: `dev`, `candidate` or `ga`.
+- `componentRelease`: DCI component release tag must be one of the following: `nightly`, `dev`, `candidate` or `ga`.
 
 **Optional**:
 

--- a/add-component
+++ b/add-component
@@ -49,6 +49,7 @@ VALID_DCI_RELEASE_TAGS=(
     dev
     candidate
     ga
+    nightly
 )
 
 VALID_DCI_TOPIC_TYPES=(


### PR DESCRIPTION
Update image to use ubi9-minimal.
Adds nightly buildtype now supported by dci-create-component Prepare to release