### PR TITLE
Fix query and update terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Some Inputs are required, while others are optional.
 
 - `dciClientId`: Remote CI client ID, this is passed as a secret.
 - `dciApiSecret`: Remote CI API secret, this is passed as a secret.
-- `dciTopics`: A comma-separated list of DCI topics, or a special term `all-<TOPIC_TYPE>` for the [latest topics](./dci-component/blob/main/add-component#L17). Where `TOPIC_TYPE`is one of: `OCP`, `OSP` or `RHEL`.
+- `dciTopics`: A comma-separated list of DCI topics, **OR** a special term `all-<PRODUCT_TYPE>` to retrieve all the active topics of a given product. Where `PRODUCT_TYPE`is one of: `OCP`, `OSP` or `RHEL`.
 
     ```yaml
     # Single topic

--- a/add-component
+++ b/add-component
@@ -8,21 +8,18 @@ function clean_up() {
 
 trap clean_up EXIT
 
-# Get the latest versions of a topic per product
-function get_topic_versions(){
-    local topic_type=${1^^}
-    declare -A limits
+# Get the active versions of a topic per product
+function get_active_topics(){
+    local product_type=${1^^}
     declare -A products
-    limits=( [OCP]=9 [OSP]=2 [RHEL]=10 )
     products=( [OCP]=OpenShift [OSP]=OpenStack [RHEL]=RHEL )
 
     # get product and limit from topic
-    product=${products[${topic_type}]}
-    limit=${limits[${topic_type}]}
+    product=${products[${product_type}]}
 
     if [[ -z ${product} ]]; then
-        echo "Invalid Topic Type: ${topic_type}"
-        echo "Valid Topic Types: ${VALID_DCI_TOPIC_TYPES[*]}"
+        echo "Invalid Product Type: ${product_type}"
+        echo "Valid Product Types: ${VALID_DCI_PRODUCT_TYPES[*]}"
         exit 1
     fi
 
@@ -34,15 +31,14 @@ function get_topic_versions(){
               jq -r '.products[].id'
     )
 
-    all_versions=( $( dcictl \
+    # Get all the active topics of a product
+    topics=( $( dcictl \
                       --format json \
                       topic-list \
-                      --where "status:active" \
-                      --where "product_id:${product_id}" \
-                      --where "name:${topic_type}*" |
-                  jq -r '.topics[0:'${limit}'][] | .name')
+                      --where "state:active,product_id:${product_id},name:${product_type}*" |
+                  jq -r '.topics[] | .name')
     )
-    echo ${all_versions[@]}
+    echo ${topics[@]}
 }
 
 VALID_DCI_RELEASE_TAGS=(
@@ -52,7 +48,7 @@ VALID_DCI_RELEASE_TAGS=(
     nightly
 )
 
-VALID_DCI_TOPIC_TYPES=(
+VALID_DCI_PRODUCT_TYPES=(
     OCP
     OSP
     RHEL
@@ -117,7 +113,7 @@ fi
 # Detect topic wildcard "all-<TOPIC_TYPE>"
 if [[ ${#TOPICS[@]} -eq 1 ]] && grep -q all- <<< "${TOPICS[0]}"; then
     old_topic=${TOPICS[0]}
-    TOPICS=( $(get_topic_versions "${TOPICS[0]#all-*}") )
+    TOPICS=( $(get_active_topics "${TOPICS[0]#all-*}") )
     if [[ $? -ne 0 ]]; then
         echo "Failed to get versions for ${old_topic}"
         exit 1


### PR DESCRIPTION
Fix a bug with the query to get the list of active topics for a product as it is retrieving a subset of components and not the active ones. Update the terminology to focus on the product and not the topic name.

Gitleaks-Sign: OC4zMC4wfDIwMjYtMDEtMjNUMTg6NDM6MjU=
Gitleaks-Hash: 4003c89315debfbfb3debaae2bac1d8ac38fbc8f

---

The previous code retrieved incomplete topics of a product, e.g.:
```Shell
$ dcictl --format json topic-list --where "status:active" --where "product_id:${product_id}" --where "name:${topic_type}*" | jq -r '.topics[0:9] | length'
9
```

vs the active topics for a product:
```Shell
$ dcictl --format json topic-list --where "state:active,product_id:${product_id},name:${topic_type}*" | jq -r '.topics | length'
14
```